### PR TITLE
Fix minArr() erroneously returning 1 in certain cases

### DIFF
--- a/GuitarChordz/Utility.cpp
+++ b/GuitarChordz/Utility.cpp
@@ -23,10 +23,12 @@ int minArr(vector<int> arr)
 {
 	if (arr.size()>0)
 	{
-		int result = max(arr[0],1);
+		int result = arr[0];
 		for (int i(1); i < arr.size(); i++)
-			if (result > arr[i] && arr[i] > 0) result = arr[i];
-
+			if (arr[i] > 0 && (result == -1 || result > arr[i]))
+				result = arr[i];
+		if (result == -1)
+			result = 1;
 		return result;
 	}
 	else return 0;


### PR DESCRIPTION
When the input array starts with -1, minArr() returns 1 even if the remaining elements are above 1.

When running the executable with the default configuration, this results in 8 skipped fingerings.
For example, this one is not generated:

    X  2  0  0  4  3   
                       
          D  G         
    ----------------   
    |  B  |  |  |  |  2
    ----------------   
    |  |  |  |  |  G  3
    ----------------   
    |  |  |  |  D# |  4
    ----------------   
    |  |  |  |  |  |  5
    ----------------   
    |  |  |  |  |  |  6
    ----------------   

But this one is:

    3  2  0  0  4  3   
                       
          D  G         
    ----------------   
    |  B  |  |  |  |  2
    ----------------   
    G  |  |  |  |  G  3
    ----------------   
    |  |  |  |  D# |  4
    ----------------   
    |  |  |  |  |  |  5
    ----------------   
    |  |  |  |  |  |  6
    ----------------   

The only difference is that the first omits one of the Gs.